### PR TITLE
fix #4: Fixed network speed calculation error

### DIFF
--- a/speedinfo.cpp
+++ b/speedinfo.cpp
@@ -119,11 +119,12 @@ void SpeedInfo::netRate(long &netDown, long &netUpload)
     line  = stream.readLine();
     line  = stream.readLine();
     while (!line.isNull()) {
+        line = line.trimmed();
         QStringList list = line.split(QRegExp("\\s{1,}"));   // 匹配任意 大于等于1个的 空白字符
 
         if (!list.isEmpty()) {
-            down = list.at(2).toLong();
-            upload = list.at(10).toLong();
+            down = list.at(1).toLong();
+            upload = list.at(9).toLong();
         }
 
         netDown += down;


### PR DESCRIPTION
Note lo device contains several blank characters, in front of the need to use trimmed to remove white space characters before and after:

```shell
$ cat /proc/net/dev
Inter-|   Receive                                                |  Transmit
 face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
    lo: 5450679577 2453388    0    0    0     0          0         0 5450679577 2453388    0    0    0     0       0          0
wlp1s0: 7063689206 5461090    0 188182    0     0          0         0 218675766 2330870    0    0    0     0       0          0
```